### PR TITLE
Select first country by default

### DIFF
--- a/kano_init_flow/keyboard_screen.py
+++ b/kano_init_flow/keyboard_screen.py
@@ -2,7 +2,7 @@
 
 # keyboard_screen.py
 #
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014, 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 


### PR DESCRIPTION
This PR sets the default country to the first one in the available list. This way after changing the continent instead of getting empty dropdown menus for country and consequently for the "advanced options"
