### PR TITLE
keyboard-screen: Adding a confirmation dialog

### DIFF
--- a/kano_init_flow/keyboard_screen.py
+++ b/kano_init_flow/keyboard_screen.py
@@ -237,7 +237,7 @@ class KeyboardScreen(Gtk.Box):
                     'Test your new keyboard layout',
                     'Make sure you can write latin characters with your new ' \
                     'layout, otherwise you won\'t be able to finish setting ' \
-                    'up your Kano. \n\n Type \'judoka\' into the box bellow ' \
+                    'up your Kano. \n\n Type \'judoka\' into the box below ' \
                     'or go back to the previous screen to choose a ' \
                     'different layout:',
                     [


### PR DESCRIPTION
If a user select a layout without latin characters, they won't be able
to register on kano world. This commit adds a test after the selection
to make sure they can type latin before they go on with the flow.

cc @alex5imon @carolineclark 

Related to: https://github.com/KanoComputing/peldins/issues/1827
