### PR TITLE
Add python-setuptools as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0)
+Build-Depends: debhelper (>=9.0.0), python-setuptools
 
 Package: kano-init-flow
 Architecture: all


### PR DESCRIPTION
This is for building the package more reliably.