### PR TITLE
Add splash for NOOBS.

### DIFF
--- a/bin/kano-init-flow
+++ b/bin/kano-init-flow
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # kano-init-flow
 #
@@ -36,6 +36,7 @@ from gi.repository import Gtk, GObject
 from kano_profile.tracker import Tracker
 
 from kano_init_flow.ui.main_window import MainWindow
+from kano.utils import get_partition_info
 
 args = docopt.docopt(__doc__)
 
@@ -44,6 +45,11 @@ GObject.threads_init()
 mw = MainWindow(start_from)
 if not mw.prepare_first_stage():
     sys.exit(mw.return_value)
+
+# if on NOOBS, cover delay using splash image
+if len(get_partition_info()) >2:
+    os.system("kano-start-splash -t 50 -b 0 /usr/share/kano-draw/media/splash.png")
+        
 Tracker()
 mw.show_all()
 Gtk.main()

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9.0.0), python-setuptools, dh-python
 
 Package: kano-init-flow
 Architecture: all
-Depends: ${misc:Depends}, gir1.2-gtk-3.0, kano-toolset (>=1.2-2),
+Depends: ${misc:Depends}, gir1.2-gtk-3.0, kano-toolset (>=2.2.0-2),
          kano-profile (>=2.2.0-5), kano-settings (>=2.2-1),
          kano-connect (>=2.0-1), kano-peripherals
 Description: Kanux initial boot


### PR DESCRIPTION
@alex5imon @pazdera 
This PR adds a splash image in the case that we are using NOOBS (and we are not doing
early termination, ie, actually going through the init flow).
This commit uses a placeholder image which will be replaced by a real one later.
Will merge for testing tomorrow, but feel free to comment anyway.
