### PR TITLE
Desktop unstick

### DIFF
--- a/kano_init_flow/stages/desktop/main.py
+++ b/kano_init_flow/stages/desktop/main.py
@@ -232,6 +232,8 @@ class Desktop(Stage):
 
         self._add_taskbar(scene, attach_callbacks=True)
 
+        scene.schedule(30, self._show_toolbar_next_button, scene)
+
         return scene
 
     def _setup_fourth_scene(self):
@@ -438,6 +440,16 @@ class Desktop(Stage):
                 self.next_stage
             )
 
+    def _show_toolbar_next_button(self, scene):
+        if not self._toolbar_next_button_shown:
+            self._toolbar_next_button_shown = True
+            scene.add_widget(
+                NextButton(),
+                Placement(0.5, 0.5, 0),
+                Placement(0.5, 0.5, 0),
+                self.fourth_scene
+            )
+
     # TODO: this is a repeat of _change_apps_speechbubble_text
     def _change_toolbar_speechbubble_text(self, widget, scene, name):
         scene.remove_widget("toolbar_speechbubble")
@@ -468,14 +480,7 @@ class Desktop(Stage):
             )
 
             # If the icon is in the toolbar, show the next button
-            if not self._toolbar_next_button_shown:
-                self._toolbar_next_button_shown = True
-                scene.add_widget(
-                    NextButton(),
-                    Placement(0.5, 0.5, 0),
-                    Placement(0.5, 0.5, 0),
-                    self.fourth_scene
-                )
+            self._show_toolbar_next_button(scene)
 
     def _add_profile_icon(self, scene, callback=None, use_default=False):
         # We always want to add the widget to the same position in each screen

--- a/kano_init_flow/ui/main_window.py
+++ b/kano_init_flow/ui/main_window.py
@@ -82,20 +82,20 @@ class MainWindow(Gtk.Window):
             overlay.add_overlay(debug_button)
 
     def _key_emergency_exit(self, widget, event):
-        if hasattr(event, 'keyval'):
-            if event.keyval in [Gdk.KEY_Q, Gdk.KEY_q] and \
-               event.state & Gdk.ModifierType.SHIFT_MASK and \
-               event.state & Gdk.ModifierType.CONTROL_MASK:
-                self._emergency_exit_cb(widget)
+        if (hasattr(event, 'keyval') and
+           event.keyval in [Gdk.KEY_Q, Gdk.KEY_q] and
+           event.state & Gdk.ModifierType.SHIFT_MASK and
+           event.state & Gdk.ModifierType.CONTROL_MASK):
+            self._emergency_exit_cb(widget)
 
         return False
 
     def _key_skip_stage(self, widget, event):
-        if hasattr(event, 'keyval'):
-            if event.keyval in [Gdk.KEY_N, Gdk.KEY_n] and \
-               event.state & Gdk.ModifierType.SHIFT_MASK and \
-               event.state & Gdk.ModifierType.CONTROL_MASK:
-                self._ctl.next_stage()
+        if (hasattr(event, 'keyval') and
+           event.keyval in [Gdk.KEY_N, Gdk.KEY_n] and
+           event.state & Gdk.ModifierType.SHIFT_MASK and
+           event.state & Gdk.ModifierType.CONTROL_MASK):
+            self._ctl.next_stage()
 
         return False
 

--- a/kano_init_flow/ui/main_window.py
+++ b/kano_init_flow/ui/main_window.py
@@ -71,6 +71,7 @@ class MainWindow(Gtk.Window):
         overlay.add_overlay(emergency_exit)
 
         self.connect('key-release-event', self._key_emergency_exit)
+        self.connect('key-release-event', self._key_skip_stage)
 
         if start_from:
             debug_button = Gtk.EventBox()
@@ -86,6 +87,15 @@ class MainWindow(Gtk.Window):
                event.state & Gdk.ModifierType.SHIFT_MASK and \
                event.state & Gdk.ModifierType.CONTROL_MASK:
                 self._emergency_exit_cb(widget)
+
+        return False
+
+    def _key_skip_stage(self, widget, event):
+        if hasattr(event, 'keyval'):
+            if event.keyval in [Gdk.KEY_N, Gdk.KEY_n] and \
+               event.state & Gdk.ModifierType.SHIFT_MASK and \
+               event.state & Gdk.ModifierType.CONTROL_MASK:
+                self._ctl.next_stage()
 
         return False
 


### PR DESCRIPTION
This PR includes:

1. The next button in the LXPanel scene will show up after 30 seconds if they didn't click on anything.
2. At any stage, you can now press `CTRL+SHIFT+N` to skip to the next one instantly (this is to help people who are stuck via zendesk).

Related to: https://github.com/KanoComputing/peldins/issues/2169

cc @alex5imon @convolu @tombettany 